### PR TITLE
Add 'Contributing' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,22 @@ Should you wish to change the key controls, you can do this by making your own
 little Haskell project (also with stack), define the configuration you want to
 use and pass it to the [`smos`](https://github.com/NorfairKing/smos/blob/development/smos/src/Smos.hs#L29)
 library function.
+
+## Contributing
+
+Smos uses [hpack](https://github.com/sol/hpack) in addition to `stack`. It
+uses a [Zifter](https://github.com/NorfairKing/zifter) script to maintain
+consistency, enforce code quality, and run tests.
+
+There is a `stack.yaml` in the project root, then a `project.yaml` under
+each project directory, e.g. `smos/project.yaml`. `hpack` generates `.cabal`
+files from these `.yaml` files, so if you need to make changes to the project
+configuration then make these changes in the appropriate `package.yaml`.
+
+To run the Zifter script, execute the following from the root project directory:
+
+```
+$ ./zift.hs run
+```
+
+This will take a long time on the initial execution.


### PR DESCRIPTION
Hi Tom,

While getting the project set up on my dev machine I encountered some points of confusion, so this small change aims to document a few of the non-obvious differences between a standard stack project and smos. Knowing about these things up front might save folks some time when they first attempt to contribute.

Please let me know if anything in here is incorrect, or you don't think it's necessary.

Thanks, Kieran.